### PR TITLE
Matching Dutch translations

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -35,8 +35,8 @@ const LANG = {
     status: 'Status',
     delivery_date: 'Bezorgdatum',
     enroute: 'Onderweg',
-    delivered: 'Afgeleverd',
-    delivery: 'Ontvangen',
+    delivered: 'Bezorgd',
+    delivery: 'Bezorging',
     distribution: 'Versturen',
     unknown: 'Onbekend',
   }


### PR DESCRIPTION
Delivery in Dutch should be ‘Bezorging’ or ‘Levering’, but since delivery_date, delivered and delivery all match each other in English let’s also match its Dutch translations to ‘Bezorgdatum’, ‘Bezorgd’ and ‘Bezorging’.